### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update 
-        sudo apt-get install libglib2.0-dev libxml2-dev uuid-dev gcc g++ default-jdk rng-tools libmysqlclient-dev libpq-dev swig python3-dev python3-setuptools default-jdk rng-tools libmysql-java
+        sudo apt-get install libglib2.0-dev libxml2-dev uuid-dev gcc g++ default-jdk rng-tools libmysqlclient-dev libpq-dev swig python3-dev python3-setuptools default-jdk rng-tools libmariadb-java
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Replaced libmysql-java with libmariadb-java because the builder system for CodeQL is now based on Ubuntu 20.04